### PR TITLE
Process valid lines where possible

### DIFF
--- a/receiver/influxdbreceiver/README.md
+++ b/receiver/influxdbreceiver/README.md
@@ -20,7 +20,7 @@ Write query parameter `precision` is optional, defaults to `ns`.
 
 Write responses:
 - 204: success, no further response needed (no content)
-- 400: permanent failure; check response body for details
+- 400: permanent failure; check response body for details, including partial writes
 - 500: retryable error; check response body for details
 
 ## Configuration
@@ -28,6 +28,8 @@ Write responses:
 The following configuration options are supported:
 
 * `endpoint` (default = localhost:8086) HTTP service endpoint for the line protocol receiver. See our [security best practices doc](https://opentelemetry.io/docs/security/config-best-practices/#protect-against-denial-of-service-attacks) to understand how to set the endpoint in different environments.
+* `enable_partial_writes` (default = false) Enable partial writes.  This replicates the behavior of InfluxDB by writing any lines in the batch that are valid.
+* `max_tracked_errors` (default = 0) Track and return errors details for each line that was dropped from the batch.  This replicates the behavior of InfluxDB and for performance reasons it can be limited.
 
 The full list of settings exposed for this receiver are documented in [config.go](config.go).
 
@@ -36,6 +38,9 @@ Example:
 receivers:
   influxdb:
     endpoint: 0.0.0.0:8080
+    enable_partial_writes: false
+    max_tracked_errors: 0
+
 ```
 
 ## Definitions

--- a/receiver/influxdbreceiver/batch_drops.go
+++ b/receiver/influxdbreceiver/batch_drops.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package influxdbreceiver
+
+import (
+	"fmt"
+	"strings"
+)
+
+type BatchDropReason string
+
+const (
+	FailedMeasurement BatchDropReason = "failed_to_parse_measurement_name"
+	FailedTag         BatchDropReason = "failed_to_parse_tag"
+	FailedField       BatchDropReason = "failed_to_parse_field"
+	FailedTimestamp   BatchDropReason = "failed_to_parse_timestamp"
+	FailedLine        BatchDropReason = "failed_to_parse_line"
+	FailedDecoder     BatchDropReason = "failed_to_parse_decoder"
+	FailedBatchAdd    BatchDropReason = "failed_to_add_to_batch"
+)
+
+type BatchDrops struct {
+	errors  []string
+	limit   int
+	reasons map[BatchDropReason]int
+}
+
+func NewBatchDrops(limit int) *BatchDrops {
+	return &BatchDrops{
+		errors:  []string{},
+		limit:   limit,
+		reasons: make(map[BatchDropReason]int),
+	}
+}
+
+func (bd *BatchDrops) AddDrop(dropReason BatchDropReason, line int, details ...string) {
+	if _, exists := bd.reasons[dropReason]; !exists {
+		bd.reasons[dropReason] = 0
+	}
+
+	bd.reasons[dropReason]++
+
+	if len(bd.errors) < bd.limit {
+		message := fmt.Sprintf("%s on line %d", dropReason, line)
+		if len(details) > 0 {
+			message += ": " + strings.Join(details, ", ")
+		}
+		bd.errors = append(bd.errors, message)
+	}
+}
+
+func (bd *BatchDrops) Errors() []string {
+	return bd.errors
+}
+
+func (bd *BatchDrops) Count() int {
+	total := 0
+	for _, count := range bd.reasons {
+		total += count
+	}
+	return total
+}
+
+func (bd *BatchDrops) Reasons() map[BatchDropReason]int {
+	return bd.reasons
+}

--- a/receiver/influxdbreceiver/config.go
+++ b/receiver/influxdbreceiver/config.go
@@ -10,4 +10,6 @@ import (
 // Config defines configuration for the InfluxDB receiver.
 type Config struct {
 	confighttp.ServerConfig `mapstructure:",squash"`
+	EnablePartialWrites     bool `mapstructure:"enable_partial_writes"`
+	MaxTrackedErrors        int  `mapstructure:"max_tracked_errors"`
 }

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver/internal/metadata"
 )
 
-func TestWriteLineProtocol_v2API(t *testing.T) {
+func TestWriteLineProtocol_v1API(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	config := &Config{
 		ServerConfig: confighttp.ServerConfig{
@@ -65,6 +65,107 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("influxdb-client-v1-batch", func(t *testing.T) {
+		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
+
+		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
+			Addr:    "http://" + addr,
+			Timeout: time.Second,
+		})
+		require.NoError(t, err)
+
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
+		require.NoError(t, err)
+
+		point1, err := influxdb1.NewPoint("cpu_temp", map[string]string{"foo": "bar"}, map[string]any{"gauge": 87.332})
+		require.NoError(t, err)
+		batchPoints.AddPoint(point1)
+
+		point2, err := influxdb1.NewPoint("memory_usage", map[string]string{"foo": "baz"}, map[string]any{"gauge": 65.123})
+		require.NoError(t, err)
+		batchPoints.AddPoint(point2)
+
+		err = client.Write(batchPoints)
+		require.NoError(t, err)
+
+		metrics := nextConsumer.lastMetricsConsumed
+		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
+			assert.Equal(t, 2, metrics.MetricCount())
+
+			metric1 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			assert.Equal(t, "cpu_temp", metric1.Name())
+			if assert.Equal(t, pmetric.MetricTypeGauge, metric1.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric1.Gauge().DataPoints().At(0).ValueType()) {
+				assert.InEpsilon(t, 87.332, metric1.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
+			}
+
+			metric2 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1)
+			assert.Equal(t, "memory_usage", metric2.Name())
+			if assert.Equal(t, pmetric.MetricTypeGauge, metric2.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric2.Gauge().DataPoints().At(0).ValueType()) {
+				assert.InEpsilon(t, 65.123, metric2.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
+			}
+		}
+	})
+
+	t.Run("influxdb-client-v1-batch-with-invalid-histogram", func(t *testing.T) {
+		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
+
+		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
+			Addr:    "http://" + addr,
+			Timeout: time.Second,
+		})
+		require.NoError(t, err)
+
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
+		require.NoError(t, err)
+
+		validPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        float64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(validPoint)
+
+		invalidPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        int64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(invalidPoint)
+
+		err = client.Write(batchPoints)
+		require.Error(t, err)
+
+		metrics := nextConsumer.lastMetricsConsumed
+		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
+			assert.Equal(t, 1, metrics.MetricCount())
+		}
+	})
+}
+
+func TestWriteLineProtocol_v2API(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+	config := &Config{
+		ServerConfig: confighttp.ServerConfig{
+			Endpoint: addr,
+		},
+	}
+	nextConsumer := new(mockConsumer)
+
+	receiver, outerErr := NewFactory().CreateMetrics(context.Background(), receivertest.NewNopSettings(metadata.Type), config, nextConsumer)
+	require.NoError(t, outerErr)
+	require.NotNil(t, receiver)
+
+	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, receiver.Shutdown(context.Background())) })
 
 	t.Run("influxdb-client-v2", func(t *testing.T) {
 		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver/internal/metadata"
 )
 
-func TestWriteLineProtocol_v1API(t *testing.T) {
+func TestWriteLineProtocol_v2API(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	config := &Config{
 		ServerConfig: confighttp.ServerConfig{
@@ -66,7 +66,46 @@ func TestWriteLineProtocol_v1API(t *testing.T) {
 		}
 	})
 
-	t.Run("influxdb-client-v1-batch", func(t *testing.T) {
+	t.Run("influxdb-client-v2", func(t *testing.T) {
+		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
+
+		o := influxdb2.DefaultOptions()
+		o.SetPrecision(time.Microsecond)
+		client := influxdb2.NewClientWithOptions("http://"+addr, "", o)
+		t.Cleanup(client.Close)
+
+		err := client.WriteAPIBlocking("my-org", "my-bucket").WriteRecord(context.Background(), "cpu_temp,foo=bar gauge=87.332")
+		require.NoError(t, err)
+
+		metrics := nextConsumer.lastMetricsConsumed
+		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
+			assert.Equal(t, 1, metrics.MetricCount())
+			metric := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			assert.Equal(t, "cpu_temp", metric.Name())
+			if assert.Equal(t, pmetric.MetricTypeGauge, metric.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric.Gauge().DataPoints().At(0).ValueType()) {
+				assert.InEpsilon(t, 87.332, metric.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
+			}
+		}
+	})
+}
+
+func TestDisablePartialWrite(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+	config := &Config{
+		ServerConfig: confighttp.ServerConfig{
+			Endpoint: addr,
+		},
+	}
+	nextConsumer := new(mockConsumer)
+
+	receiver, outerErr := NewFactory().CreateMetrics(context.Background(), receivertest.NewNopSettings(metadata.Type), config, nextConsumer)
+	require.NoError(t, outerErr)
+	require.NotNil(t, receiver)
+
+	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, receiver.Shutdown(context.Background())) })
+
+	t.Run("valid-batch", func(t *testing.T) {
 		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
 
 		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
@@ -90,24 +129,10 @@ func TestWriteLineProtocol_v1API(t *testing.T) {
 		require.NoError(t, err)
 
 		metrics := nextConsumer.lastMetricsConsumed
-		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
-			assert.Equal(t, 2, metrics.MetricCount())
-
-			metric1 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-			assert.Equal(t, "cpu_temp", metric1.Name())
-			if assert.Equal(t, pmetric.MetricTypeGauge, metric1.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric1.Gauge().DataPoints().At(0).ValueType()) {
-				assert.InEpsilon(t, 87.332, metric1.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
-			}
-
-			metric2 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1)
-			assert.Equal(t, "memory_usage", metric2.Name())
-			if assert.Equal(t, pmetric.MetricTypeGauge, metric2.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric2.Gauge().DataPoints().At(0).ValueType()) {
-				assert.InEpsilon(t, 65.123, metric2.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
-			}
-		}
+		assert.Equal(t, 2, metrics.MetricCount())
 	})
 
-	t.Run("influxdb-client-v1-batch-with-invalid-histogram", func(t *testing.T) {
+	t.Run("batch-with-invalid-histogram", func(t *testing.T) {
 		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
 
 		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
@@ -118,6 +143,17 @@ func TestWriteLineProtocol_v1API(t *testing.T) {
 
 		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
 		require.NoError(t, err)
+
+		invalidPoint, err := influxdb1.NewPoint("invalid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        int64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(invalidPoint)
 
 		validPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
 			"bucket_0_10":  5,
@@ -130,33 +166,22 @@ func TestWriteLineProtocol_v1API(t *testing.T) {
 		require.NoError(t, err)
 		batchPoints.AddPoint(validPoint)
 
-		invalidPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
-			"bucket_0_10":  5,
-			"bucket_10_20": 15,
-			"bucket_20_30": 10,
-			"bucket_inf":   0,
-			"count":        int64(30),
-			"sum":          float64(450.0),
-		})
-		require.NoError(t, err)
-		batchPoints.AddPoint(invalidPoint)
-
 		err = client.Write(batchPoints)
 		require.Error(t, err)
 
 		metrics := nextConsumer.lastMetricsConsumed
-		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
-			assert.Equal(t, 1, metrics.MetricCount())
-		}
+		assert.Zero(t, metrics.MetricCount())
+
 	})
 }
 
-func TestWriteLineProtocol_v2API(t *testing.T) {
+func TestEnablePartialWrites(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	config := &Config{
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: addr,
 		},
+		EnablePartialWrites: true,
 	}
 	nextConsumer := new(mockConsumer)
 
@@ -167,26 +192,149 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, receiver.Shutdown(context.Background())) })
 
-	t.Run("influxdb-client-v2", func(t *testing.T) {
+	t.Run("valid-batch", func(t *testing.T) {
 		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
 
-		o := influxdb2.DefaultOptions()
-		o.SetPrecision(time.Microsecond)
-		client := influxdb2.NewClientWithOptions("http://"+addr, "", o)
-		t.Cleanup(client.Close)
+		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
+			Addr:    "http://" + addr,
+			Timeout: time.Second,
+		})
+		require.NoError(t, err)
 
-		err := client.WriteAPIBlocking("my-org", "my-bucket").WriteRecord(context.Background(), "cpu_temp,foo=bar gauge=87.332")
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
+		require.NoError(t, err)
+
+		point1, err := influxdb1.NewPoint("cpu_temp", map[string]string{"foo": "bar"}, map[string]any{"gauge": 87.332})
+		require.NoError(t, err)
+		batchPoints.AddPoint(point1)
+
+		point2, err := influxdb1.NewPoint("memory_usage", map[string]string{"foo": "baz"}, map[string]any{"gauge": 65.123})
+		require.NoError(t, err)
+		batchPoints.AddPoint(point2)
+
+		err = client.Write(batchPoints)
 		require.NoError(t, err)
 
 		metrics := nextConsumer.lastMetricsConsumed
-		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
-			assert.Equal(t, 1, metrics.MetricCount())
-			metric := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-			assert.Equal(t, "cpu_temp", metric.Name())
-			if assert.Equal(t, pmetric.MetricTypeGauge, metric.Type()) && assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, metric.Gauge().DataPoints().At(0).ValueType()) {
-				assert.InEpsilon(t, 87.332, metric.Gauge().DataPoints().At(0).DoubleValue(), 0.001)
-			}
-		}
+		assert.Equal(t, 2, metrics.MetricCount())
+	})
+
+	t.Run("batch-with-invalid-histogram", func(t *testing.T) {
+		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
+
+		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
+			Addr:    "http://" + addr,
+			Timeout: time.Second,
+		})
+		require.NoError(t, err)
+
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
+		require.NoError(t, err)
+
+		invalidPoint, err := influxdb1.NewPoint("invalid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        int64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(invalidPoint)
+
+		validPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        float64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(validPoint)
+
+		err = client.Write(batchPoints)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partial write")
+
+		metrics := nextConsumer.lastMetricsConsumed
+		assert.Equal(t, metrics.MetricCount(), 1)
+
+	})
+}
+
+func TestEnableTrackingErrors(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+	config := &Config{
+		ServerConfig: confighttp.ServerConfig{
+			Endpoint: addr,
+		},
+		EnablePartialWrites: true,
+		MaxTrackedErrors:    1,
+	}
+	nextConsumer := new(mockConsumer)
+
+	receiver, outerErr := NewFactory().CreateMetrics(context.Background(), receivertest.NewNopSettings(metadata.Type), config, nextConsumer)
+	require.NoError(t, outerErr)
+	require.NotNil(t, receiver)
+
+	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, receiver.Shutdown(context.Background())) })
+
+	t.Run("batch-with-multiple-invalid-histograms", func(t *testing.T) {
+		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
+
+		client, err := influxdb1.NewHTTPClient(influxdb1.HTTPConfig{
+			Addr:    "http://" + addr,
+			Timeout: time.Second,
+		})
+		require.NoError(t, err)
+
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
+		require.NoError(t, err)
+
+		invalidPoint, err := influxdb1.NewPoint("first_invalid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        int64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(invalidPoint)
+
+		anohterInvalidPoint, err := influxdb1.NewPoint("second_invalid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        int64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(anohterInvalidPoint)
+
+		validPoint, err := influxdb1.NewPoint("valid_histogram", map[string]string{"foo": "quux"}, map[string]any{
+			"bucket_0_10":  5,
+			"bucket_10_20": 15,
+			"bucket_20_30": 10,
+			"bucket_inf":   0,
+			"count":        float64(30),
+			"sum":          float64(450.0),
+		})
+		require.NoError(t, err)
+		batchPoints.AddPoint(validPoint)
+
+		err = client.Write(batchPoints)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partial write")
+		assert.Contains(t, err.Error(), "first_invalid_histogram")
+		assert.NotContains(t, err.Error(), "second_invalid_histogram")
+
+		metrics := nextConsumer.lastMetricsConsumed
+		assert.Equal(t, metrics.MetricCount(), 1)
+
 	})
 }
 


### PR DESCRIPTION
The current implementation will drop all points in a batch if any of them are invalid.  Instead, process all the valid lines and drop only the invalid ones.  Keep the existing behavior of returning StatusBadRequest if any lines are invalid and return a json response with success / failure counts for the batch.